### PR TITLE
Make force configurable when adding users

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ rabbitmq_users_definitions:
   - vhost   : vhost1
     user    : user2
     password: password2
+    force   : no
     tags:
     - administrator
 ```

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -13,7 +13,7 @@
     read_priv=.*
     write_priv=.*
     state=present
-    force=yes
+    force="{{ item.force|default('yes') }}"
   with_items: rabbitmq_users_definitions
 
 - name: remove guest user


### PR DESCRIPTION
I re-use the same username for staging/production vhosts and having the
user re-created every time drops the vhost configuration for the first
configured host. By allowing the option to be configured I can keep the
same username for both hosts.

The default value set matches the old default.
