### PR TITLE
Add an option to not use SSL listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ support other OS.
 `rabbitmq_cacert`|String|Name of the CA certificate file. Will be prefixed by `rabbitmq_` and postfixed by `.pem`|`cacert`
 `rabbitmq_server_key`|String|Name of the SSL key file. Will be prefixed by `rabbitmq_` and postfixed by `.pem`|`server_key`
 `rabbitmq_cert_key`|String|Name of the SSL certificate file. Will be prefixed by `rabbitmq_` and postfixed by `.pem`|`server_cert`
+`rabbitmq_ssl`|Boolean|Define if we need to use SSL|`true`
 
 #### Default configuration file
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ rabbitmq_federation: false
 rabbitmq_cacert     : "cacert"
 rabbitmq_server_key : "server_key"
 rabbitmq_server_cert: "server_cert"
+rabbitmq_ssl        : true
 
 # ######################
 # RabbitMQ Configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
     group=rabbitmq
     mode=0750
     state=directory
+  when: rabbitmq_ssl
 
 - name: copy the ssl certificates
   copy:
@@ -34,6 +35,7 @@
     - "{{ rabbitmq_cacert }}"
     - "{{ rabbitmq_server_key }}"
     - "{{ rabbitmq_server_cert }}"
+  when: rabbitmq_ssl
 
 - name: generate the configuration of rabbitmq
   template:

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -1,8 +1,9 @@
 [
   {rabbit, [
     {% if rabbitmq_conf_tcp_listeners_address != '' %}
-    {tcp_listeners, [{"{{ rabbitmq_conf_tcp_listeners_address }}", {{ rabbitmq_conf_tcp_listeners_port }}}]},
+    {tcp_listeners, [{"{{ rabbitmq_conf_tcp_listeners_address }}", {{ rabbitmq_conf_tcp_listeners_port }}}]}{% if rabbitmq_ssl %},{% endif %}
     {% endif %}
+    {% if rabbitmq_ssl %}
     {ssl_listeners, [{"{{ rabbitmq_conf_ssl_listeners_address }}", {{ rabbitmq_conf_ssl_listeners_port }}}]},
     {ssl_options, [
       {cacertfile, "{{rabbitmq_conf_ssl_options_cacertfile}}"},
@@ -11,5 +12,6 @@
       {verify, verify_peer},
       {fail_if_no_peer_cert,{{rabbitmq_conf_ssl_options_fail_if_no_peer_cert}}}
       ]}
+    {% endif %}
   ]}
 ].

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -8,6 +8,8 @@ rabbitmq_users_definitions:
     user    : sensu
     password: placeholder
 
+rabbitmq_ssl: true
+
 rabbitmq_federation: true
 
 rabbitmq_federation_configuration:


### PR DESCRIPTION
The use case for this is if the server is running internally and not
connected to the internet, there is simply no need for SSL.

The default has been set add a SSL listener and matches the current
behavior.
