### PR TITLE
Rabbit doesn't enable itself on boot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 # handlers file for rabbitmq
 - name: restart rabbitmq-server
-  service: name=rabbitmq-server state=restarted
+  service: name=rabbitmq-server state=restarted enabled=yes


### PR DESCRIPTION
Updated handler to enable the service when installed.
