### PR TITLE
README Fixes: server cert var, typo, and some quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Playbook to install and configure rabbitmq. Will come with various
 configuration tweaking later on.
 
-If you wish to discuss modifications, or help to support more plateforms, open
+If you wish to discuss modifications, or help to support more platforms, open
 an issue.
 
 ## Supported system
@@ -27,12 +27,12 @@ support other OS.
 |----|----|-----------|-------|
 `rabbitmq_conf_tcp_listeners_address`|String|listening address for the tcp interface|`''`
 `rabbitmq_conf_tcp_listeners_port`|Integer|listening port for the tcp interface|`5672`
-`rabbitmq_conf_ssl_listeners_address`|String|listening address for the ssl interface|'0.0.0.0'`
+`rabbitmq_conf_ssl_listeners_address`|String|listening address for the ssl interface|`'0.0.0.0'`
 `rabbitmq_conf_ssl_listeners_port`|Integer|listening port for the ssl interface|`5671`
 `rabbitmq_conf_ssl_options_cacertfile`|String|Path the CA certificate|`"/etc/rabbitmq/ssl/cacert.pem"`
 `rabbitmq_conf_ssl_options_certfile`|String|Path to the server certificate|`"/etc/rabbitmq/ssl/server_cert.pem"`
 `rabbitmq_conf_ssl_options_keyfile`|String|Path to the private key file|`"/etc/rabbitmq/ssl/server_key.pem"`
-`rabbitmq_conf_ssl_options_fail_if_no_peer_cert`|Boolean|Value of the `fail_if_no_peer_cert` SSL option|"true"
+`rabbitmq_conf_ssl_options_fail_if_no_peer_cert`|Boolean|Value of the `fail_if_no_peer_cert` SSL option|`"true"`
 
 #### Plugins
 


### PR DESCRIPTION
Server cert key variable is referred to as `rabbitmq_cert_key` in README but it's `rabbitmq_server_cert` everywhere else.

Other changes are just a typo fix and some quoting in the tables.

Thanks for this playbook!
