### PR TITLE
Disable tcp listener if address is blank

### DIFF
--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -2,6 +2,8 @@
   {rabbit, [
     {% if rabbitmq_conf_tcp_listeners_address != '' %}
     {tcp_listeners, [{"{{ rabbitmq_conf_tcp_listeners_address }}", {{ rabbitmq_conf_tcp_listeners_port }}}]}{% if rabbitmq_ssl %},{% endif %}
+    {% else %}
+    {tcp_listeners, []}{% if rabbitmq_ssl %},{% endif %}
     {% endif %}
     {% if rabbitmq_ssl %}
     {ssl_listeners, [{"{{ rabbitmq_conf_ssl_listeners_address }}", {{ rabbitmq_conf_ssl_listeners_port }}}]},


### PR DESCRIPTION
Current behavior is to still listen on the TCP port even if the TCP listen address is blank. If there is no `tcp_listeners` in `rabbitmq.config` it defaults to 5672: https://www.rabbitmq.com/configure.html#config-items.

You have to explicitly give `[]` to turn off the TCP listener. http://stackoverflow.com/q/19806313
