### PR TITLE
Fixed vhost attribute

### DIFF
--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -14,7 +14,7 @@
   rabbitmq_user:
     user={{ item.user }}
     password={{ item.password }}
-    vhost={{ item.name | default('/', false) }}
+    vhost={{ item.vhost | default('/', false) }}
     node={{ item.node | default('rabbit') }}
     tags={{ (item.tags | default('')) | join(',') }}
     configure_priv=.*


### PR DESCRIPTION
When creating users the playbook was only using the '/' vhost because the task was using item.name vs. item.vhost.
