### PR TITLE
Update playbook installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ an issue.
 
 Use Ansible galaxy to install this playbook:
 
-    $ ansible-galaxy install Mayeu.rabbitmq,1.1.0
+    $ ansible-galaxy install Mayeu.RabbitMQ,1.2.0
 
 The `master` branch should currently be considered instable. Please avoid using
 it for something else than test purpose :)


### PR DESCRIPTION
Running the current installation instruction yields the following:

```
$ ansible-galaxy install Mayeu.rabbitmq,1.1.0
 downloading role 'rabbitmq', owned by Mayeu
Sorry, Mayeu.rabbitmq was not found on galaxy.ansible.com.
```

This PR fixes the error, and updates the instruction for version 1.2.0.
