### PR TITLE
Fix : Missing rabbitmq_conf_tcp_listeners_port in template file

### DIFF
--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -3,7 +3,7 @@
     {% if rabbitmq_conf_tcp_listeners_address != '' %}
     {tcp_listeners, [{"{{ rabbitmq_conf_tcp_listeners_address }}", {{ rabbitmq_conf_tcp_listeners_port }}}]}{% if rabbitmq_ssl %},{% endif %}
     {% else %}
-    {tcp_listeners, []}{% if rabbitmq_ssl %},{% endif %}
+    {tcp_listeners, [{{rabbitmq_conf_tcp_listeners_port}}]}{% if rabbitmq_ssl %},{% endif %}
     {% endif %}
     {% if rabbitmq_ssl %}
     {ssl_listeners, [{"{{ rabbitmq_conf_ssl_listeners_address }}", {{ rabbitmq_conf_ssl_listeners_port }}}]},


### PR DESCRIPTION
rabbitmq_conf_tcp_listeners_port variable is not inserted
in rabbitmq.config.j2, result being rabbitmq server does not open
any port
