### PR TITLE
Change command module to yum module for installing epel repo

### DIFF
--- a/tasks/install/redhat.yml
+++ b/tasks/install/redhat.yml
@@ -1,8 +1,5 @@
 - name: install EPEL repository (RedHat)
-  command: "{{ item }}"
-  with_items:
-    - wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-    - rpm -Uvh epel-release-6*.rpm
+  yum: name=http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
 
 - name: install rabbitmq-server dependencies (RedHat)
   yum: name="{{ item }}" state=present


### PR DESCRIPTION
Fixes failure when epel repo is already installed. This is due to 'rpm -Uvh' which exits with failure status if the rpm is already installed.
