### PR TITLE
Using Erlang official repo.

### DIFF
--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -1,4 +1,13 @@
 ---
+#Installing Erlang from official repo
+- name: Downloading Erlang's repo
+  get_url: url=http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb dest=/tmp/erlang-solutions_1.0_all.deb
+
+- name: Installing Erlang's repo
+  apt: deb=/tmp/erlang-solutions_1.0_all.deb
+
+- name: Installing Erlang from official repo
+  apt: name=erlang update_cache=yes
 
 # RabbitMQ official install
 - name: "add the official rabbitmq repository's key"


### PR DESCRIPTION
Hello,

RabbitMQ doesnt support SSL while using old Erlang version, and this error will occur : 

```
=ERROR REPORT==== 27-Aug-2015::22:22:47 ===
The installed version of Erlang (R15B01) contains the bug OTP-10905,
which makes it impossible to disable SSLv3. This makes the system
vulnerable to the POODLE attack. SSL listeners for AMQP have therefore
been disabled.

You are advised to upgrade to a recent Erlang version; R16B01 is the
first version in which this bug is fixed, but later is usually
better.

If you cannot upgrade now and want to re-enable SSL listeners, you can
set the config item 'ssl_allow_poodle_attack' to 'true' in the
'rabbit' section of your configuration file.
```

Installing Erlang's repo fixes it.
