### PR TITLE
Idempotency issue installing epel rpm

### DIFF
--- a/tasks/install/redhat.yml
+++ b/tasks/install/redhat.yml
@@ -1,8 +1,5 @@
 - name: install EPEL repository (RedHat)
-  command: "{{ item }}"
-  with_items:
-    - wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-    - rpm -Uvh epel-release-6*.rpm
+  yum: name=http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
 
 - name: install rabbitmq-server dependencies (RedHat)
   yum: name="{{ item }}" state=present


### PR DESCRIPTION
On CentOS there appears to be an idempotency issue running the playbook in the epel install task.
The playbook fails when run a second time because the rpm is already installed.

```
TASK: [rabbitmq | install EPEL repository (RedHat)] ***************************
changed: [rabbit-standalone] => (item=wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm)
failed: [rabbit-standalone] => (item=rpm -Uvh epel-release-6*.rpm) => {"changed": true, "cmd": ["rpm", "-Uvh", "epel-release-6*.rpm"], "delta": "0:00:00.078862", "end": "2015-10-08 22:34:17.983237", "item": "rpm -Uvh epel-release-6*.rpm", "rc": 1, "start": "2015-10-08 22:34:17.904375", "warnings": ["Consider using yum module rather than running rpm"]}
stderr:         package epel-release-6-8.noarch is already installed
stdout: Preparing...                ##################################################
```

Using the yum module, similar to how the rabbitmq-server rpm is being pulled in, resolves this issue.
