### PR TITLE
Remove relative path from copy src param

### DIFF
--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -7,7 +7,7 @@
 
 - name: add the official rabbitmq repository
   copy:
-    src=../../files/rabbitmq.list
+    src=files/rabbitmq.list
     dest=/etc/apt/sources.list.d/
     backup=yes
   register: aptrepo


### PR DESCRIPTION
Under Ansible 2.0 the debian install `copy` fails attempting to load the file. The relative path `src` seems to start with my playbook as a base path. It does not seem to look for the file relative to the role path.

Removing the relative `../../` gets it working again under 2.0.0 rc1. It loads the file from the role `files` directory as expected.
