### PR TITLE
Remove "equals" (`=`) from multi-line YAML directives.

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,21 +1,21 @@
 ---
 - name: create the ssl folder for rabbitmq
   file:
-    path=/etc/rabbitmq/ssl/
-    owner=rabbitmq
-    group=rabbitmq
-    mode=0750
-    state=directory
+    path: /etc/rabbitmq/ssl/
+    owner: rabbitmq
+    group: rabbitmq
+    mode: 0750
+    state: directory
   when: rabbitmq_ssl
 
 - name: copy the ssl certificates
   copy:
-    src={{ item.src }}
-    dest={{ item.dest }}
-    owner=rabbitmq
-    group=rabbitmq
-    mode=0640
-    backup=yes
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: rabbitmq
+    group: rabbitmq
+    mode: 0640
+    backup: yes
   with_items:
     - src: "{{ rabbitmq_cacert }}"
       dest: "{{ rabbitmq_conf_ssl_options_cacertfile }}"
@@ -27,21 +27,21 @@
 
 - name: generate the configuration of rabbitmq
   template:
-    src=rabbitmq.config.j2
-    dest=/etc/rabbitmq/rabbitmq.config
-    owner=rabbitmq
-    group=rabbitmq
-    mode=0644
-    backup=yes
+    src: rabbitmq.config.j2
+    dest: /etc/rabbitmq/rabbitmq.config
+    owner: rabbitmq
+    group: rabbitmq
+    mode: 0644
+    backup: yes
   notify: restart rabbitmq-server
 
 - name: generate environment-specific configuration
   template:
-    src=rabbitmq-env.conf.j2
-    dest=/etc/rabbitmq/rabbitmq-env.conf
-    owner=rabbitmq
-    group=rabbitmq
-    mode=0644
-    backup=yes
+    src: rabbitmq-env.conf.j2
+    dest: /etc/rabbitmq/rabbitmq-env.conf
+    owner: rabbitmq
+    group: rabbitmq
+    mode: 0644
+    backup: yes
   notify: restart rabbitmq-server
   when: rabbitmq_conf_env is defined

--- a/tasks/federation.yml
+++ b/tasks/federation.yml
@@ -1,30 +1,30 @@
 ---
 - name: active the federation plugin
   rabbitmq_plugin:
-    names=rabbitmq_federation
-    new_only=yes
+    names: rabbitmq_federation
+    new_only: yes
   register: federation_plugin
 
 - name: restart RabbitMQ to be able to setup federation
   service:
-    name=rabbitmq-server
-    state=restarted
+    name: rabbitmq-server
+    state: restarted
   when: federation_plugin.changed
 
 - name: set the federation-upstream parameter
   rabbitmq_parameter:
-    component=federation-upstream
-    name={{ item.name }}
-    vhost={{ item.vhost | default('/', false) }}
-    value='{{ item.value }}'
+    component: federation-upstream
+    name: "{{ item.name }}"
+    vhost: "{{ item.vhost | default('/', false) }}"
+    value: "'{{ item.value }}'"
   with_items: rabbitmq_federation_configuration
 
 - name: set the policy for the federation
   rabbitmq_policy:
-    name={{ item.name }}
-    vhost={{ item.vhost | default('/', false) }}
-    pattern={{ item.pattern }}
-    tags={{ item.tags }}
+    name: "{{ item.name }}"
+    vhost: "{{ item.vhost | default('/', false) }}"
+    pattern: "{{ item.pattern }}"
+    tags: "{{ item.tags }}"
   with_items: rabbitmq_policy_configuration
 
 - name: get the version of rabbitmq
@@ -35,9 +35,9 @@
 # http://www.rabbitmq.com/release-notes/README-3.3.0.txt
 - name: set the local username for the federation
   rabbitmq_parameter:
-    component=federation
-    name=local-username
-    value='"{{ item.local_username | default( 'guest', false ) }}"'
-    vhost={{ item.vhost | default( '/', false) }}
+    component: federation
+    name: local-username
+    value: "'"{{ item.local_username | default( 'guest', false ) }}"'"
+    vhost: "{{ item.vhost | default( '/', false) }}"
   with_items: rabbitmq_federation_configuration
   when: rabbitmq_version.stdout | version_compare('3.3.0', '<')

--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -7,9 +7,9 @@
 
 - name: add the official rabbitmq repository
   copy:
-    src=../../files/rabbitmq.list
-    dest=/etc/apt/sources.list.d/
-    backup=yes
+    src: ../../files/rabbitmq.list
+    dest: /etc/apt/sources.list.d/
+    backup: yes
   register: aptrepo
   when: not rabbitmq_os_package
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,8 +1,8 @@
 ---
 - name: enable plugins
   rabbitmq_plugin:
-    names={{ rabbitmq_plugins | join(',') }}
-    new_only={{ rabbitmq_new_only }}
+    names: "{{ rabbitmq_plugins | join(',') }}"
+    new_only: "{{ rabbitmq_new_only }}"
   notify: restart rabbitmq-server
   when: rabbitmq_plugins != []
 
@@ -13,8 +13,8 @@
 
 - name: disable plugins if none added in the configuration
   rabbitmq_plugin:
-    name={{ item }}
-    state=disabled
+    name: "{{ item }}"
+    state: disabled
   notify: restart rabbitmq-server
   with_items: result.stdout_lines
   when: rabbitmq_plugins == []

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -3,39 +3,39 @@
   service: name=rabbitmq-server state=started
 
 - name: add rabbitmq vhost
-  rabbitmq_vhost: >
-    name={{ item.name }}
-    node={{ item.node | default('rabbit') }}
-    tracing={{ item.tracing | default('no') }}
-    state=present
+  rabbitmq_vhost:
+    name: "{{ item.name }}"
+    node: "{{ item.node | default('rabbit') }}"
+    tracing: "{{ item.tracing | default('no') }}"
+    state: present
   with_items: rabbitmq_vhost_definitions
 
 - name: add rabbitmq user and set privileges
   rabbitmq_user:
-    user={{ item.user }}
-    password={{ item.password }}
-    vhost={{ item.vhost | default('/', false) }}
-    node={{ item.node | default('rabbit') }}
-    tags={{ (item.tags | default('')) | join(',') }}
-    configure_priv={{ item.configure_priv | default('.*') }}
-    read_priv={{ item.read_priv | default('.*') }}
-    write_priv={{ item.write_priv | default('.*') }}
-    state=present
-    force={{ item.force|default('yes') }}
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    vhost: "{{ item.vhost | default('/', false) }}"
+    node: "{{ item.node | default('rabbit') }}"
+    tags: "{{ (item.tags | default('')) | join(',') }}"
+    configure_priv: "{{ item.configure_priv | default('.*') }}"
+    read_priv: "{{ item.read_priv | default('.*') }}"
+    write_priv: "{{ item.write_priv | default('.*') }}"
+    state: present
+    force: "{{ item.force|default('yes') }}"
   with_items: rabbitmq_users_definitions
 
 - name: remove guest user (hostname)
   rabbitmq_user:
-    user=guest
-    vhost=/
-    node="rabbit@{{ ansible_hostname }}"
-    state=absent
+    user: guest
+    vhost: /
+    node: ""rabbit@{{ ansible_hostname }}""
+    state: absent
   register: rm_guest_hostname
   ignore_errors: true
 
 - name: remove guest user (default)
   rabbitmq_user:
-    user=guest
-    vhost=/
-    state=absent
+    user: guest
+    vhost: /
+    state: absent
   when: rm_guest_hostname|failed


### PR DESCRIPTION
This prevents syntax highlighting from breaking in Vim. Also stringify
YAML directives with macro definitions ({{ macro }}) for clarity.
