### PR TITLE
Debian install fixes

### DIFF
--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -2,7 +2,7 @@
 
 # RabbitMQ official install
 - name: "add the official rabbitmq repository's key"
-  apt_key: url=https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+  apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
   when: not rabbitmq_os_package
 
 - name: add the official rabbitmq repository

--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -7,7 +7,7 @@
 
 - name: add the official rabbitmq repository
   copy:
-    src=../../files/rabbitmq.list
+    src=rabbitmq.list
     dest=/etc/apt/sources.list.d/
     backup=yes
   register: aptrepo


### PR DESCRIPTION
Update the signing key URL, as it has changed sometime between when this repo was published and now.  Use a _more_ relative path for the `rabbitmq.list` file, so that this role is a bit more flexible.